### PR TITLE
Category groups

### DIFF
--- a/src/Pages/ImportFile.elm
+++ b/src/Pages/ImportFile.elm
@@ -20,7 +20,7 @@ import Maybe.Extra
 import Page
 import Parser
 import Persistence.Account exposing (Account)
-import Persistence.Category exposing (Category, category)
+import Persistence.Category as Category exposing (Category, category)
 import Persistence.Data exposing (Data)
 import Persistence.ImportProfile exposing (ImportProfile)
 import Persistence.RawEntry exposing (rawEntry, sha1)
@@ -105,7 +105,7 @@ update data msg model =
             let
                 dataWithNewCategories =
                     newCats
-                        |> List.map (\name -> category 0 (name ++ " (auto)") name)
+                        |> List.map (\name -> category 0 (name ++ " (auto)") name Category.Expense)
                         |> (\cs -> Storage.addCategories cs data)
 
                 categories =

--- a/src/Persistence/Category.elm
+++ b/src/Persistence/Category.elm
@@ -1,4 +1,4 @@
-module Persistence.Category exposing (Categories, Category, CategoryV0, category, codec, fromV0, v0Codec)
+module Persistence.Category exposing (Categories, Category, CategoryGroup(..), CategoryV0, category, codec, fromV0, v0Codec)
 
 import Dict exposing (Dict)
 import Serialize as S
@@ -9,7 +9,21 @@ type alias Categories =
 
 
 type alias Category =
-    CategoryV0
+    CategoryV1
+
+
+type alias CategoryV1 =
+    { id : Int
+    , name : String
+    , short : String
+    , group : CategoryGroup
+    }
+
+
+type CategoryGroup
+    = Income
+    | Expense
+    | Internal
 
 
 type alias CategoryV0 =
@@ -19,14 +33,20 @@ type alias CategoryV0 =
     }
 
 
-category : Int -> String -> String -> Category
-category i s1 s2 =
-    CategoryV0 i s1 s2
+category : Int -> String -> String -> CategoryGroup -> Category
+category =
+    CategoryV1
 
 
 fromV0 : Dict Int CategoryV0 -> Categories
 fromV0 dict =
-    dict
+    Dict.map (\_ -> v0v1) dict
+
+
+v0v1 : CategoryV0 -> CategoryV1
+v0v1 c =
+    -- using Expense as the default, that's the most common case
+    CategoryV1 c.id c.name c.short Expense
 
 
 
@@ -39,26 +59,65 @@ codec =
 
 
 categoryCodec : S.Codec String Category
+categoryCodec : S.Codec String CategoryV1
 categoryCodec =
     S.customType
-        (\v0Encoder value ->
+        (\v0Encoder v1Encoder value ->
             case value of
                 V0 record ->
                     v0Encoder record
+
+                V1 record ->
+                    v1Encoder record
         )
         |> S.variant1 V0 v0Codec
+        |> S.variant1 V1 v1Codec
         |> S.finishCustomType
         |> S.map
             (\value ->
                 case value of
                     V0 storage ->
+                        v0v1 storage
+
+                    V1 storage ->
                         storage
             )
-            V0
+            V1
 
 
 type StorageVersions
     = V0 CategoryV0
+    | V1 CategoryV1
+
+
+v1Codec : S.Codec String CategoryV1
+v1Codec =
+    S.record CategoryV1
+        |> S.field .id S.int
+        |> S.field .name S.string
+        |> S.field .short S.string
+        |> S.field .group categoryGroupCodec
+        |> S.finishRecord
+
+
+categoryGroupCodec : S.Codec String CategoryGroup
+categoryGroupCodec =
+    S.customType
+        (\a b c value ->
+            case value of
+                Income ->
+                    a
+
+                Expense ->
+                    b
+
+                Internal ->
+                    c
+        )
+        |> S.variant0 Income
+        |> S.variant0 Expense
+        |> S.variant0 Internal
+        |> S.finishCustomType
 
 
 v0Codec : S.Codec String CategoryV0


### PR DESCRIPTION
Add a new grouping to categories that allows to mark them as "expense" or "income". This shall allow to group statements in the monthly overview in a more meaningful way. There's also a third group "internal" meant for transfers between different accounts which are neither expense nor income.

Original description:

~The addition of groups to categories required a backwards-incompatible change of the data format. So I made a first real example of how an automatic data migration and backwards-compatible data de-serialization would look like.~

~It turned out much more verbose than I expected!~

~Conceptually, I consider the `Data` record to be the database, and every field in that record a table.~

~I have been wondering whether it would be worthwhile to prepare the data model in a way such that every such "table" in the database gets its own versioning layer. That way I could have created a new version of the categories without touching the level-0-decoder for the `Data` type. Such changes would only be required for the addition or removal of tables. WDYT?~

~I'll experiment a bit to see how this would play out in practice.~