### PR TITLE
Allow table-level versioning w/o changes to Data module

### DIFF
--- a/src/Persistence/Account.elm
+++ b/src/Persistence/Account.elm
@@ -1,4 +1,4 @@
-module Persistence.Account exposing (Account, AccountStart, AccountV0, Accounts, account, codec, v0Codec)
+module Persistence.Account exposing (Account, AccountStart, AccountV0, Accounts, account, codec, fromV0, v0Codec)
 
 import Dict exposing (Dict)
 import Serialize as S
@@ -10,6 +10,11 @@ type alias Accounts =
 
 type alias Account =
     AccountV0
+
+
+fromV0 : Dict Int AccountV0 -> Accounts
+fromV0 dict =
+    dict
 
 
 type alias AccountV0 =

--- a/src/Persistence/Category.elm
+++ b/src/Persistence/Category.elm
@@ -1,4 +1,4 @@
-module Persistence.Category exposing (Categories, Category, CategoryV0, category, codec, v0Codec)
+module Persistence.Category exposing (Categories, Category, CategoryV0, category, codec, fromV0, v0Codec)
 
 import Dict exposing (Dict)
 import Serialize as S
@@ -10,6 +10,11 @@ type alias Categories =
 
 type alias Category =
     CategoryV0
+
+
+fromV0 : Dict Int CategoryV0 -> Categories
+fromV0 dict =
+    dict
 
 
 type alias CategoryV0 =

--- a/src/Persistence/Data.elm
+++ b/src/Persistence/Data.elm
@@ -87,17 +87,32 @@ dataCodec =
             (\value ->
                 case value of
                     V0 storage ->
-                        storage
+                        v0toV1 storage
 
                     V1 storage ->
                         storage
             )
-            V0
+            V1
+
+
+
+-- DataV0 has too intrinsic knowledge about the individual modules
+-- Define per-module forward adaptor path once
+
+
+v0toV1 : DataV0 -> DataV1
+v0toV1 v0 =
+    DataV1
+        (RawEntry.fromV0 v0.rawEntries)
+        (Account.fromV0 v0.accounts)
+        (Category.fromV0 v0.categories)
+        (ImportProfile.fromV0 v0.importProfiles)
+        v0.autoIncrement
 
 
 v1Codec : S.Codec String DataV1
 v1Codec =
-    S.record DataV0
+    S.record DataV1
         |> S.field .rawEntries RawEntry.codec
         |> S.field .accounts Account.codec
         |> S.field .categories Category.codec

--- a/src/Persistence/ImportProfile.elm
+++ b/src/Persistence/ImportProfile.elm
@@ -1,4 +1,4 @@
-module Persistence.ImportProfile exposing (DateFormat(..), ImportProfile, ImportProfileV0, ImportProfiles, codec, importProfile, v0Codec)
+module Persistence.ImportProfile exposing (DateFormat(..), ImportProfile, ImportProfileV0, ImportProfiles, codec, fromV0, importProfile, v0Codec)
 
 import Dict exposing (Dict)
 import Serialize as S
@@ -10,6 +10,11 @@ type alias ImportProfiles =
 
 type alias ImportProfile =
     ImportProfileV0
+
+
+fromV0 : Dict Int ImportProfileV0 -> ImportProfiles
+fromV0 dict =
+    dict
 
 
 type alias ImportProfileV0 =

--- a/src/Persistence/RawEntry.elm
+++ b/src/Persistence/RawEntry.elm
@@ -1,4 +1,4 @@
-module Persistence.RawEntry exposing (Categorization(..), RawEntries, RawEntry, RawEntryV0, SplitCatEntry, codec, rawEntry, sha1, v0Codec)
+module Persistence.RawEntry exposing (Categorization(..), RawEntries, RawEntry, RawEntryV0, SplitCatEntry, codec, fromV0, rawEntry, sha1, v0Codec)
 
 import Dict exposing (Dict)
 import Persistence.Category exposing (Category)
@@ -13,6 +13,11 @@ type alias RawEntries =
 
 type alias RawEntry =
     RawEntryV0
+
+
+fromV0 : Dict String RawEntryV0 -> RawEntries
+fromV0 dict =
+    dict
 
 
 type alias RawEntryV0 =


### PR DESCRIPTION
Because the data module has knowledge about the structure of the v0 versions of all tables, it needs to be able to migrate forward every table from v0 to latest.

Introduce an interface in the modules to provide that forward-migration function for every table and use it in the Data module. Currently these implementations are the id function because at the current stage, v0 = current for all modules. But this change shall allow to evolve modules individually without any changes required to the Data module.