### PR TITLE
Create import profiles while importing a file

### DIFF
--- a/src/Components/Icons.elm
+++ b/src/Components/Icons.elm
@@ -1,4 +1,4 @@
-module Components.Icons exposing (checkMark, copy, folderPlus, infoMark, loader, triangleDown, triangleUp, warnTriangle)
+module Components.Icons exposing (checkMark, copy, folderPlus, infoMark, loader, plusSquare, triangleDown, triangleUp, warnTriangle)
 
 import Element exposing (Attribute, Element, el)
 import FeatherIcons exposing (Icon)
@@ -48,6 +48,11 @@ folderPlus =
 loader : List (Attribute msg) -> Int -> Element msg
 loader =
     basicIcon FeatherIcons.loader
+
+
+plusSquare : List (Attribute msg) -> Int -> Element msg
+plusSquare =
+    basicIcon FeatherIcons.plusSquare
 
 
 basicIcon : Icon -> List (Attribute msg) -> Int -> Element msg

--- a/src/Components/Input.elm
+++ b/src/Components/Input.elm
@@ -1,0 +1,16 @@
+module Components.Input exposing (brightButton, button)
+
+import Config exposing (color, style)
+import Element exposing (Element, text)
+import Element.Background as Background
+import Element.Input as Input
+
+
+button : msg -> String -> Element msg
+button msg label =
+    Input.button style.button { onPress = Just msg, label = text label }
+
+
+brightButton : msg -> String -> Element msg
+brightButton msg label =
+    Input.button (style.button ++ [ Background.color color.extraBrightAccent ]) { onPress = Just msg, label = text label }


### PR DESCRIPTION
This adds an "import profile creation wizard" to the file import flow. Instead of selecting an existing profile, the user can select to create one and interactively select the columns that should be used by the import profile, while providing a preview of the result.

It has a few rough edges and isn't a beauty, but it works.