### PR TITLE
Implement date selection via range slider

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -26,6 +26,7 @@
             "elm-community/result-extra": "2.4.0",
             "elm-explorations/test": "2.1.1",
             "feathericons/elm-feather": "1.5.0",
+            "hrldcpr/elm-cons": "3.1.0",
             "isaacseymour/deprecated-time": "1.0.0",
             "mdgriffith/elm-ui": "1.1.8"
         },

--- a/src/Components/Icons.elm
+++ b/src/Components/Icons.elm
@@ -1,4 +1,4 @@
-module Components.Icons exposing (checkMark, copy, cross, edit, folderPlus, infoMark, loader, plusSquare, triangleDown, triangleUp, wand, warnTriangle)
+module Components.Icons exposing (checkMark, copy, cross, edit, folderPlus, infoMark, loader, plusSquare, triangleDown, triangleLeft, triangleRight, triangleUp, wand, warnTriangle)
 
 import Element exposing (Attribute, Element, el)
 import FeatherIcons exposing (Icon, withStrokeWidth, withViewBox)
@@ -11,14 +11,21 @@ triangleUp attrs size =
         Element.html
             (FeatherIcons.triangle
                 |> FeatherIcons.toHtml
-                    [ Attributes.fill "fill"
-                    , Attributes.height <| String.fromInt size
+                    [ Attributes.height <| String.fromInt size
                     ]
             )
 
 
 triangleDown attrs size =
     el [ Element.rotate <| degrees 180 ] <| triangleUp attrs size
+
+
+triangleLeft attrs size =
+    el [ Element.rotate <| degrees 270 ] <| triangleUp attrs size
+
+
+triangleRight attrs size =
+    el [ Element.rotate <| degrees 90 ] <| triangleUp attrs size
 
 
 checkMark : List (Attribute msg) -> Int -> Element msg

--- a/src/Components/RangeSlider.elm
+++ b/src/Components/RangeSlider.elm
@@ -1,0 +1,197 @@
+module Components.RangeSlider exposing (Model, Msg, init, max, min, update, view)
+
+{-| A slider input with two thumbs.
+
+Elm-UI only has a slider with a single thumb. This component fakes a two-thumb slider by
+placing two sliders next to one another and adjusting their sizes according to the current
+selection. In operates on a discrete list of items (rather than on a continuous range).
+
+It is not perfect and the thumbs jump around a little bit when the thumbs are reaching their maximum
+positions, but it works well enough. Does not play well with too fine-grained ranges because the thumbs overlap
+each other and make it hard to change focus from one slider to the other.
+
+-}
+
+import Components.Icons exposing (triangleLeft, triangleRight)
+import Config exposing (color, size)
+import Cons exposing (Cons)
+import Element exposing (Element, behindContent, centerY, el, fill, fillPortion, height, inFront, moveDown, moveLeft, px, row, spacing, text, width)
+import Element.Background as Background
+import Element.Font as Font
+import Element.Input as Input exposing (Label, Thumb, labelHidden)
+
+
+type Msg a
+    = SetMin Int a
+    | SetMax Int a
+
+
+type Side
+    = Min
+    | Max
+
+
+type Model a
+    = Model
+        { options : Cons a
+        , min : a
+        , max : a
+        , iMin : Int
+        , iMax : Int
+        , focus : Side
+        , optionCount : Int
+        }
+
+
+min : Model a -> a
+min model =
+    case model of
+        Model m ->
+            m.min
+
+
+max : Model a -> a
+max model =
+    case model of
+        Model m ->
+            m.max
+
+
+init : a -> List a -> Model a
+init head tail =
+    let
+        options =
+            Cons.cons head tail
+
+        size =
+            Cons.length options
+    in
+    Model
+        { options = options
+        , min = head
+        , max = Cons.reverse options |> Cons.head
+        , iMin = 0
+        , iMax = size - 1
+        , focus = Min
+        , optionCount = size
+        }
+
+
+update : Msg a -> Model a -> Model a
+update msg model =
+    case ( msg, model ) of
+        ( SetMin i a, Model m ) ->
+            Model { m | min = a, iMin = i, focus = Min }
+
+        ( SetMax i a, Model m ) ->
+            Model { m | max = a, iMax = i, focus = Max }
+
+
+view : String -> (a -> String) -> Model a -> Element (Msg a)
+view label format model =
+    case model of
+        Model m ->
+            let
+                pad =
+                    if m.iMin == m.iMax then
+                        1
+
+                    else
+                        0
+
+                ( lSize, rSize ) =
+                    case m.focus of
+                        Min ->
+                            ( m.iMax, m.optionCount - m.iMax - pad )
+
+                        Max ->
+                            ( m.iMin + 1 - pad, m.optionCount - m.iMin - 1 )
+
+                ( lMax, rMin ) =
+                    case m.focus of
+                        Min ->
+                            ( m.iMax, m.iMax - 1 + pad )
+
+                        Max ->
+                            ( m.iMin + 1 - pad, m.iMin )
+
+                sliderMin =
+                    slider Min lSize 0 lMax m.iMin (onChange m.options SetMin)
+
+                sliderMax =
+                    slider Max rSize rMin (m.optionCount - 1) m.iMax (onChange m.options SetMax)
+            in
+            row [ width fill, spacing size.m ]
+                [ text label
+                , text (format m.min)
+                , row
+                    [ width fill, height (px size.xl), behindContent track ]
+                    [ sliderMin
+                    , el [ width (fillPortion pad) ] Element.none
+                    , sliderMax
+                    ]
+                , text (format m.max)
+                ]
+
+
+type alias Slider msg =
+    { onChange : Float -> msg
+    , label : Label msg
+    , min : Float
+    , max : Float
+    , value : Float
+    , thumb : Thumb
+    , step : Maybe Float
+    }
+
+
+onChange : Cons a -> (Int -> a -> Msg a) -> (Float -> Msg a)
+onChange values msg selection =
+    let
+        i =
+            round selection
+
+        a =
+            Cons.take (i + 1) values |> List.reverse |> List.head |> Maybe.withDefault (Cons.head values)
+    in
+    msg i a
+
+
+{-| Thumb size and icon size need to be aligned in order for the highlighting / handling to look and feel right
+-}
+thumbSize =
+    px 20
+
+
+thumbIconSize =
+    32
+
+
+slider : Side -> Int -> Int -> Int -> Int -> (Float -> Msg a) -> Element (Msg a)
+slider side size minIdx maxIdx valIdx onChangeMsg =
+    let
+        ( label, handle ) =
+            case side of
+                Min ->
+                    ( "Min"
+                    , triangleRight [ moveLeft 6, moveDown 2, Font.color color.brightAccent ] thumbIconSize
+                    )
+
+                Max ->
+                    ( "Max"
+                    , triangleLeft [ moveLeft -6, moveDown -2, Font.color color.brightAccent ] thumbIconSize
+                    )
+    in
+    Input.slider [ width (fillPortion size), height fill, centerY ]
+        { onChange = onChangeMsg
+        , label = labelHidden label
+        , min = toFloat minIdx
+        , max = toFloat maxIdx
+        , value = toFloat valIdx
+        , thumb = Input.thumb [ width thumbSize, height thumbSize, inFront handle ]
+        , step = Just 1
+        }
+
+
+track =
+    el [ width fill, height (px 1), centerY, Background.color color.darkAccent ] Element.none

--- a/src/Pages/Book.elm
+++ b/src/Pages/Book.elm
@@ -41,13 +41,13 @@ page shared _ =
         { init =
             case shared of
                 Shared.Model.None ->
-                    init [] []
+                    init [] [] []
 
                 Shared.Model.Problem _ ->
-                    init [] []
+                    init [] [] []
 
                 Shared.Model.Loaded data ->
-                    init (Dict.values data.accounts) (Dict.values data.categories)
+                    init (Dict.values data.accounts) (Dict.values data.categories) (Dict.values data.rawEntries)
         , update = dataUpdate shared update
         , view = dataView shared "Book" view
         , subscriptions = \_ -> Sub.none
@@ -70,13 +70,13 @@ type CatAttempt
     | Known String Categorization
 
 
-init : List Account -> List Category -> () -> ( Model, Effect Msg )
-init accounts categories _ =
+init : List Account -> List Category -> List RawEntry -> () -> ( Model, Effect Msg )
+init accounts categories entries _ =
     ( { notification = Notification.None
       , ordering = dateAsc
       , editCategories = False
       , categoryEdits = Dict.empty
-      , filters = Filter.init accounts categories Filter
+      , filters = Filter.init accounts categories (List.map .date entries) Filter
       , toBeDeleted = []
       }
     , Effect.none
@@ -238,8 +238,7 @@ showFilters : Filter.Model Msg -> List Account -> Element Msg
 showFilters model accounts =
     column [ spacing size.s ]
         [ el style.h2 <| text "Filters"
-        , Filter.yearFilter model
-        , Filter.monthFilter model
+        , Filter.dateRangeFilter model
         , Filter.descriptionFilter ApplyPattern SavePattern model
         , Filter.categoryFilter model
         , Filter.accountFilter accounts model

--- a/src/Pages/Monthly.elm
+++ b/src/Pages/Monthly.elm
@@ -63,7 +63,7 @@ type alias Model =
 
 init : List Account -> () -> ( Model, Effect Msg )
 init accounts _ =
-    ( { filters = Filter.init accounts [] Filter
+    ( { filters = Filter.init accounts [] [] Filter
       , tab = Overview
       }
     , Effect.none

--- a/src/Processing/Filter.elm
+++ b/src/Processing/Filter.elm
@@ -4,7 +4,7 @@ import Persistence.Account exposing (Account)
 import Persistence.Category exposing (Category)
 import Processing.BookEntry exposing (BookEntry)
 import Regex
-import Time.Date as Date
+import Time.Date as Date exposing (Date)
 
 
 type alias Filter =
@@ -21,14 +21,9 @@ any l =
     \e -> List.any (\f -> f e) l
 
 
-filterMonth : Int -> BookEntry -> Bool
-filterMonth i e =
-    Date.month e.date == i
-
-
-filterYear : Int -> BookEntry -> Bool
-filterYear i e =
-    Date.year e.date == i
+filterDateRange : (Date -> Date -> Order) -> Date -> Date -> BookEntry -> Bool
+filterDateRange order min max be =
+    (not <| order min be.date == GT) && (not <| order be.date max == GT)
 
 
 filterDescription : String -> BookEntry -> Bool


### PR DESCRIPTION
Typing in year/month is weird and inflexible. It allows selecting dates that have no relevance given the data, requires Int -> String parsing and error handling and does not allow to select multiple months at once.

This replaces the year/month filter fields on the Book page with a two-thumb slider allowing to select a date range. Some extra work was required to fake a two-thumb slider input since Elm-UI does not provide such natively.