### PR TITLE
Use Integer index for RawEntry table

### DIFF
--- a/src/Pages/Home_.elm
+++ b/src/Pages/Home_.elm
@@ -145,7 +145,7 @@ showDataSummary : Data -> List (Element Msg)
 showDataSummary data =
     let
         entries =
-            data.rawEntries |> Dict.size |> String.fromInt
+            data.rawEntries.entries |> Dict.size |> String.fromInt
 
         accounts =
             data.accounts |> Dict.size |> String.fromInt

--- a/src/Pages/Monthly.elm
+++ b/src/Pages/Monthly.elm
@@ -34,7 +34,7 @@ page shared _ =
                     init [] []
 
                 Loaded data ->
-                    init (Dict.values data.accounts) (Dict.values data.rawEntries)
+                    init (Dict.values data.accounts) (Dict.values data.rawEntries.entries)
 
                 Problem _ ->
                     init [] []

--- a/src/Processing/BookEntry.elm
+++ b/src/Processing/BookEntry.elm
@@ -7,7 +7,7 @@ import Time.Date exposing (Date)
 
 
 type alias BookEntry =
-    { id : String
+    { id : Int
     , date : Date
     , description : String
     , amount : Int

--- a/src/Processing/Model.elm
+++ b/src/Processing/Model.elm
@@ -19,7 +19,7 @@ getEntries data filters order =
 
 getEntriesAndErrors : Data -> List EntryFilter -> Ordering BookEntry -> ( List BookEntry, List String )
 getEntriesAndErrors data filters order =
-    Dict.values data.rawEntries
+    Dict.values data.rawEntries.entries
         |> List.map (enrichRow data)
         |> Result.Extra.partition
         |> Tuple.mapFirst (List.filter (all filters))

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -99,7 +99,7 @@ dataSummary model =
         Loaded data ->
             let
                 entries =
-                    data.rawEntries |> Dict.size
+                    data.rawEntries.entries |> Dict.size
 
                 accounts =
                     data.accounts |> Dict.size


### PR DESCRIPTION
Since identity-based ids by hashing the content of entries was removed in d83674a, there is no need to use String-typed ids for book entries. Hashing an auto-increment value to artificially create this id is weird.

Use integers as ids for entries instead. This requires a codec migration on the Data level, since no versioning on the key side of the RawEntry dict is available.

This change moves the versioning one level up, such that the entire RawEntriess model can evolve without other versioning in the Data model. This is directly used by adding an auto-increment value to the RawEntries model which is used within that exclusively.