### PR TITLE
Introduce the YearMonth type

### DIFF
--- a/src/Pages/Accounts.elm
+++ b/src/Pages/Accounts.elm
@@ -14,8 +14,10 @@ import Persistence.Data exposing (Data)
 import Persistence.Storage as Storage
 import Route exposing (Route)
 import Shared exposing (dataSummary)
-import Util.Formats exposing (formatEuro)
+import Time.Date as Date
+import Util.Formats exposing (formatEuro, formatYearMonth)
 import Util.Layout exposing (dataUpdate, dataView)
+import Util.YearMonth as YearMonth
 
 
 page : Shared.Model -> Route () -> Page Model Msg
@@ -102,8 +104,8 @@ update data msg model =
                 | editing = Existing a
                 , name = a.name
                 , balance = String.fromInt a.start.amount
-                , year = String.fromInt a.start.year
-                , month = String.fromInt a.start.month
+                , year = String.fromInt (YearMonth.toDate a.start.yearMonth |> Date.year)
+                , month = String.fromInt (YearMonth.toDate a.start.yearMonth |> Date.month)
               }
             , Effect.none
             )
@@ -241,7 +243,7 @@ showData data _ =
                                 ]
                   }
                 , T.textColumn "Name" .name
-                , T.textColumn "Starting Month" (\a -> String.fromInt a.start.year ++ "/" ++ String.fromInt a.start.month)
+                , T.textColumn "Starting Month" (.start >> .yearMonth >> formatYearMonth)
                 , T.styledColumn "Starting Balance" (.start >> .amount >> formatEuro)
                 ]
             }

--- a/src/Persistence/Account.elm
+++ b/src/Persistence/Account.elm
@@ -1,7 +1,9 @@
 module Persistence.Account exposing (Account, AccountStart, AccountV0, Accounts, account, codec, fromV0, v0Codec)
 
 import Dict exposing (Dict)
+import Persistence.YearMonth as YMC
 import Serialize as S
+import Util.YearMonth as YearMonth exposing (YearMonth)
 
 
 type alias Accounts =
@@ -9,28 +11,48 @@ type alias Accounts =
 
 
 type alias Account =
-    AccountV0
+    AccountV1
+
+
+type alias AccountV1 =
+    { id : Int
+    , name : String
+    , start : AccountStartV1
+    }
 
 
 type alias AccountV0 =
     { id : Int
     , name : String
-    , start : AccountStart
+    , start : AccountStartV0
     }
 
 
 type alias AccountStart =
+    AccountStartV1
+
+
+type alias AccountStartV1 =
+    { amount : Int, yearMonth : YearMonth }
+
+
+type alias AccountStartV0 =
     { amount : Int, year : Int, month : Int }
 
 
 account : Int -> String -> Int -> Int -> Int -> Account
 account id n a y m =
-    AccountV0 id n (AccountStart a y m)
+    AccountV1 id n (AccountStartV1 a (YearMonth.new y m))
 
 
 fromV0 : Dict Int AccountV0 -> Accounts
-fromV0 dict =
-    dict
+fromV0 =
+    Dict.map (\_ a -> v0v1 a)
+
+
+v0v1 : AccountV0 -> AccountV1
+v0v1 a =
+    AccountV1 a.id a.name (AccountStartV1 a.start.amount (YearMonth.new a.start.year a.start.month))
 
 
 
@@ -45,24 +67,41 @@ codec =
 accountCodec : S.Codec e Account
 accountCodec =
     S.customType
-        (\v0Encoder value ->
+        (\v0Encoder v1Encoder value ->
             case value of
                 V0 record ->
                     v0Encoder record
+
+                V1 record ->
+                    v1Encoder record
         )
         |> S.variant1 V0 v0Codec
+        |> S.variant1 V1 v1Codec
         |> S.finishCustomType
         |> S.map
             (\value ->
                 case value of
                     V0 storage ->
+                        v0v1 storage
+
+                    V1 storage ->
                         storage
             )
-            V0
+            V1
 
 
 type StorageVersions
     = V0 AccountV0
+    | V1 AccountV1
+
+
+v1Codec : S.Codec e AccountV1
+v1Codec =
+    S.record AccountV1
+        |> S.field .id S.int
+        |> S.field .name S.string
+        |> S.field .start accountStartV1Codec
+        |> S.finishRecord
 
 
 v0Codec : S.Codec e AccountV0
@@ -70,13 +109,21 @@ v0Codec =
     S.record AccountV0
         |> S.field .id S.int
         |> S.field .name S.string
-        |> S.field .start accountStartCodec
+        |> S.field .start accountStartV0Codec
         |> S.finishRecord
 
 
-accountStartCodec : S.Codec e AccountStart
-accountStartCodec =
-    S.record AccountStart
+accountStartV1Codec : S.Codec e AccountStartV1
+accountStartV1Codec =
+    S.record AccountStartV1
+        |> S.field .amount S.int
+        |> S.field .yearMonth YMC.codec
+        |> S.finishRecord
+
+
+accountStartV0Codec : S.Codec e AccountStartV0
+accountStartV0Codec =
+    S.record AccountStartV0
         |> S.field .amount S.int
         |> S.field .year S.int
         |> S.field .month S.int

--- a/src/Persistence/YearMonth.elm
+++ b/src/Persistence/YearMonth.elm
@@ -1,0 +1,15 @@
+module Persistence.YearMonth exposing (codec)
+
+import Serialize as S
+import Util.YearMonth as YearMonth exposing (YearMonth)
+
+
+{-| YearMonth is a simple integer and could be encoded as such.
+Encoding its components instead leads to higher human-readability
+of the encoded json data. This is not strictly required, but improves
+the portability of the serialization format.
+-}
+codec : S.Codec e YearMonth
+codec =
+    S.tuple S.int S.int
+        |> S.map (\( y, m ) -> YearMonth.new y m) YearMonth.components

--- a/src/Util/Formats.elm
+++ b/src/Util/Formats.elm
@@ -1,9 +1,10 @@
-module Util.Formats exposing (formatDate, formatEuro, formatEuroStr, formatYearMonth)
+module Util.Formats exposing (formatDate, formatEuro, formatEuroStr, formatYearMonth, formatYearMonthNumeric)
 
 import Config exposing (color)
 import Element exposing (Element, alignRight, el, text)
 import Element.Font as Font
 import Time.Date as Date exposing (Date)
+import Util.YearMonth as YearMonth exposing (YearMonth)
 
 
 formatEuroStr : Int -> String
@@ -59,8 +60,21 @@ formatDate date =
     String.join "-" <| List.map (String.fromInt >> String.padLeft 2 '0') <| [ Date.year date, Date.month date, Date.day date ]
 
 
-formatYearMonth : Date -> String
-formatYearMonth date =
+formatYearMonthNumeric : YearMonth -> String
+formatYearMonthNumeric yearMonth =
+    let
+        ( year, month ) =
+            YearMonth.components yearMonth
+    in
+    String.join "-" [ String.fromInt year, String.padLeft 2 '0' <| String.fromInt <| month ]
+
+
+formatYearMonth : YearMonth -> String
+formatYearMonth yearMonth =
+    let
+        date =
+            YearMonth.toDate yearMonth
+    in
     String.join " "
         [ case Date.month date of
             1 ->

--- a/src/Util/YearMonth.elm
+++ b/src/Util/YearMonth.elm
@@ -1,0 +1,75 @@
+module Util.YearMonth exposing (YearMonth, add, compare, components, fromDate, new, range, toDate, zero)
+
+import Time.Date as Date exposing (Date)
+
+
+{-| A combination of year and month, as the number of months since Jan 1970, which is the 0 value.
+-}
+type YearMonth
+    = YM Int
+
+
+new : Int -> Int -> YearMonth
+new year month =
+    Date.date year month 1 |> fromDate
+
+
+zero : YearMonth
+zero =
+    YM 0
+
+
+add : Int -> YearMonth -> YearMonth
+add months (YM i) =
+    YM (i + months)
+
+
+compare : YearMonth -> YearMonth -> Order
+compare (YM a) (YM b) =
+    Basics.compare a b
+
+
+range : List YearMonth -> List YearMonth
+range yms =
+    let
+        is =
+            yms |> List.map (\(YM i) -> i)
+
+        iMin =
+            List.minimum is
+
+        iMax =
+            List.maximum is
+    in
+    Maybe.map2 List.range iMin iMax |> Maybe.withDefault [] |> List.map YM
+
+
+fromDate : Date -> YearMonth
+fromDate date =
+    YM ((Date.year date - 1970) * 12 + Date.month date - 1)
+
+
+toDate : YearMonth -> Date
+toDate yearMonth =
+    let
+        ( year, month ) =
+            components yearMonth
+    in
+    Date.date year month 1
+
+
+components : YearMonth -> ( Int, Int )
+components (YM i) =
+    let
+        year =
+            i // 12 + 1970
+
+        month =
+            remainderBy 12 i + 1
+    in
+    if month >= 1 then
+        ( year, month )
+
+    else
+        -- for negative i, remainder is negative
+        ( year - 1, month + 12 )

--- a/tests/Aggregation.elm
+++ b/tests/Aggregation.elm
@@ -9,6 +9,7 @@ import Processing.Aggregator exposing (Aggregator)
 import Processing.BookEntry exposing (BookEntry, Categorization(..))
 import Test exposing (..)
 import Time.Date as Date
+import Util.YearMonth as YearMonth
 
 
 cat1 =
@@ -34,12 +35,12 @@ account2 =
 
 entries : List BookEntry
 entries =
-    [ BookEntry "a" (Date.date 2023 3 1) "" 2 account1 (Single cat1)
-    , BookEntry "b" (Date.date 2023 3 2) "" 2 account1 (Single cat2)
-    , BookEntry "c" (Date.date 2023 4 4) "" 2 account2 (Single cat1)
-    , BookEntry "d" (Date.date 2023 4 6) "" 2 account1 (Single cat2)
-    , BookEntry "e" (Date.date 2023 4 9) "" 2 account1 (Single cat2)
-    , BookEntry "f" (Date.date 2023 5 4) "" 2 account1 (Single cat1)
+    [ BookEntry 1 (Date.date 2023 3 1) "" 2 "" account1 (Single cat1)
+    , BookEntry 2 (Date.date 2023 3 2) "" 2 "" account1 (Single cat2)
+    , BookEntry 3 (Date.date 2023 4 4) "" 2 "" account2 (Single cat1)
+    , BookEntry 4 (Date.date 2023 4 6) "" 2 "" account1 (Single cat2)
+    , BookEntry 5 (Date.date 2023 4 9) "" 2 "" account1 (Single cat2)
+    , BookEntry 6 (Date.date 2023 5 4) "" 2 "" account1 (Single cat1)
     ]
 
 
@@ -49,7 +50,7 @@ aggregate_book_entries =
         [ test "aggregates non-running sums, ignoring start values" <|
             \_ ->
                 (aggregate
-                    (Date.date 2023 2 1)
+                    (YearMonth.new 2023 2)
                     (Dict.fromList [ ( "Sum", 10 ) ])
                     [ Aggregator "Sum" .amount False ]
                     entries
@@ -60,15 +61,15 @@ aggregate_book_entries =
                     -- - if there is no entry for a given month, the value is absent
                     -- - list ends where the entries above end
                     |> Expect.equal
-                        [ { month = Date.date 2023 2 1, columns = Dict.empty }
-                        , { month = Date.date 2023 3 1, columns = Dict.fromList [ ( "Sum", 4 ) ] }
-                        , { month = Date.date 2023 4 1, columns = Dict.fromList [ ( "Sum", 6 ) ] }
-                        , { month = Date.date 2023 5 1, columns = Dict.fromList [ ( "Sum", 2 ) ] }
+                        [ { month = YearMonth.new 2023 2, columns = Dict.empty }
+                        , { month = YearMonth.new 2023 3, columns = Dict.fromList [ ( "Sum", 4 ) ] }
+                        , { month = YearMonth.new 2023 4, columns = Dict.fromList [ ( "Sum", 6 ) ] }
+                        , { month = YearMonth.new 2023 5, columns = Dict.fromList [ ( "Sum", 2 ) ] }
                         ]
         , test " aggregates for running sums, using the start value" <|
             \_ ->
                 (aggregate
-                    (Date.date 2023 2 1)
+                    (YearMonth.new 2023 2)
                     (Dict.fromList [ ( "Cumulative", 10 ) ])
                     [ Aggregator "Cumulative" .amount True ]
                     entries
@@ -77,9 +78,9 @@ aggregate_book_entries =
                     -- - Monthly sums are carried over to next month
                     -- - starting sum is included in the sums
                     |> Expect.equal
-                        [ { month = Date.date 2023 2 1, columns = Dict.fromList [ ( "Cumulative", 10 ) ] }
-                        , { month = Date.date 2023 3 1, columns = Dict.fromList [ ( "Cumulative", 14 ) ] }
-                        , { month = Date.date 2023 4 1, columns = Dict.fromList [ ( "Cumulative", 20 ) ] }
-                        , { month = Date.date 2023 5 1, columns = Dict.fromList [ ( "Cumulative", 22 ) ] }
+                        [ { month = YearMonth.new 2023 2, columns = Dict.fromList [ ( "Cumulative", 10 ) ] }
+                        , { month = YearMonth.new 2023 3, columns = Dict.fromList [ ( "Cumulative", 14 ) ] }
+                        , { month = YearMonth.new 2023 4, columns = Dict.fromList [ ( "Cumulative", 20 ) ] }
+                        , { month = YearMonth.new 2023 5, columns = Dict.fromList [ ( "Cumulative", 22 ) ] }
                         ]
         ]

--- a/tests/YearMonth.elm
+++ b/tests/YearMonth.elm
@@ -1,0 +1,38 @@
+module YearMonth exposing (..)
+
+import Expect
+import Test exposing (Test, describe, test)
+import Time.Date as Date
+import Util.YearMonth as YearMonth
+
+
+components : Test
+components =
+    describe "Year Month components"
+        [ test "2024-07" <| \_ -> YearMonth.components (YearMonth.new 2024 7) |> Expect.equal ( 2024, 7 )
+        , test "1968-12" <| \_ -> YearMonth.components (YearMonth.new 1968 12) |> Expect.equal ( 1968, 12 )
+        , test "1969-01" <| \_ -> YearMonth.components (YearMonth.new 1969 1) |> Expect.equal ( 1969, 1 )
+        , test "1969-02" <| \_ -> YearMonth.components (YearMonth.new 1969 2) |> Expect.equal ( 1969, 2 )
+        , test "1969-11" <| \_ -> YearMonth.components (YearMonth.new 1969 11) |> Expect.equal ( 1969, 11 )
+        , test "1969-12" <| \_ -> YearMonth.components (YearMonth.new 1969 12) |> Expect.equal ( 1969, 12 )
+        , test "1970-01" <| \_ -> YearMonth.components (YearMonth.new 1970 1) |> Expect.equal ( 1970, 1 )
+        , test "1970-02" <| \_ -> YearMonth.components (YearMonth.new 1970 2) |> Expect.equal ( 1970, 2 )
+        , test "1970-12" <| \_ -> YearMonth.components (YearMonth.new 1970 12) |> Expect.equal ( 1970, 12 )
+        , test "1971-01" <| \_ -> YearMonth.components (YearMonth.new 1971 1) |> Expect.equal ( 1971, 1 )
+        ]
+
+
+dates : Test
+dates =
+    describe "YearMonth and dates"
+        [ test "To date and back are inverse (1)" <|
+            \_ -> YearMonth.new 1234 1 |> YearMonth.toDate |> YearMonth.fromDate |> Expect.equal (YearMonth.new 1234 1)
+        , test "To date and back are inverse (2)" <|
+            \_ -> YearMonth.new 2345 12 |> YearMonth.toDate |> YearMonth.fromDate |> Expect.equal (YearMonth.new 2345 12)
+        , test "To yearMonth and back are is inverse for month and year, strips day (1)" <|
+            \_ -> Date.date 1403 4 1 |> YearMonth.fromDate |> YearMonth.toDate |> Expect.equal (Date.date 1403 4 1)
+        , test "To yearMonth and backare is inverse for month and year, strips day (2)" <|
+            \_ -> Date.date 1998 8 10 |> YearMonth.fromDate |> YearMonth.toDate |> Expect.equal (Date.date 1998 8 1)
+        , test "To yearMonth and backare is inverse for month and year, strips day (3)" <|
+            \_ -> Date.date 2023 12 31 |> YearMonth.fromDate |> YearMonth.toDate |> Expect.equal (Date.date 2023 12 1)
+        ]


### PR DESCRIPTION
Various places require the representation of a month in a given year, but without the day. Using the Date type is clunky, especially for ranges and comparisons.

Introducing the YearMonth type, which counts the number of months since January 1970 as an integer instead. The basic integer nature is kept as an implementation detail only though, serializing as the (year, month) tuple for persistence and never displaying the raw number in the UI.