### PR TITLE
Review statements after import

### DIFF
--- a/src/Components/Filter.elm
+++ b/src/Components/Filter.elm
@@ -65,7 +65,7 @@ dateRange dates accounts =
 
 
 type Msg
-    = DateRange RangeSlider.Selection
+    = DateRange (RangeSlider.Selection YearMonth)
     | Descr String
     | DescrRegex Bool
     | PatternCreateStart

--- a/src/Components/Filter.elm
+++ b/src/Components/Filter.elm
@@ -1,4 +1,4 @@
-module Components.Filter exposing (Model, Msg(..), accountFilter, categoryFilter, dateRangeFilter, descriptionFilter, init, toAggregateDateFilter, toEntryFilter, update)
+module Components.Filter exposing (Model, Msg(..), accountFilter, categoryFilter, dateRangeFilter, descriptionFilter, getDateRange, init, toAggregateDateFilter, toEntryFilter, update)
 
 import Components.Icons exposing (wand)
 import Components.Input exposing (button, disabledButton)
@@ -38,13 +38,17 @@ type alias Model =
     }
 
 
-init : List Account -> List Category -> List Date -> Model
-init accounts categories dates =
+init : List Account -> List Category -> List Date -> Maybe ( Date, Date ) -> Model
+init accounts categories dates initialRange =
     let
         ( dateRangeStart, tail ) =
             dateRange dates accounts |> List.Extra.uncons |> Maybe.withDefault ( YearMonth.zero, [] )
+
+        initialSelection : Selection YearMonth
+        initialSelection =
+            initialRange |> Maybe.map (\( min, max ) -> Range (YearMonth.fromDate min) (YearMonth.fromDate max)) |> Maybe.withDefault (Last 12)
     in
-    { dateRange = RangeSlider.init dateRangeStart tail True (Last 12)
+    { dateRange = RangeSlider.init dateRangeStart tail True initialSelection
     , descr = ""
     , descrIsRegex = False
     , creatingPattern = Nothing
@@ -368,3 +372,8 @@ allCategories =
 
 uncategorized =
     category -2 "-- Uncategorized --" "" Internal []
+
+
+getDateRange : Model -> ( Date, Date )
+getDateRange model =
+    RangeSlider.getRange model.dateRange |> Tuple.mapBoth YearMonth.toDate YearMonth.toDate

--- a/src/Components/RangeSlider.elm
+++ b/src/Components/RangeSlider.elm
@@ -1,4 +1,4 @@
-module Components.RangeSlider exposing (Model, Selection(..), init, max, min, update, view)
+module Components.RangeSlider exposing (Model, Selection(..), getRange, init, max, min, update, view)
 
 {-| A slider input with two thumbs.
 
@@ -104,6 +104,11 @@ rangeIndices msg options =
 
         Range l u ->
             ( indexOfMin l, indexOfMax u )
+
+
+getRange : Model a -> ( a, a )
+getRange (Model m) =
+    ( get m.options m.min, get m.options m.max )
 
 
 range : Cons a -> Int -> Int -> Selection a

--- a/src/Components/RangeSlider.elm
+++ b/src/Components/RangeSlider.elm
@@ -22,10 +22,10 @@ import Element.Font as Font
 import Element.Input as Input exposing (Label, Thumb, labelHidden)
 
 
-type Selection
+type Selection a
     = All
     | Last Int
-    | Range Int Int
+    | Range a a
 
 
 type Side
@@ -59,11 +59,11 @@ max (Model m) =
     get m.options m.max
 
 
-init : a -> List a -> Bool -> Selection -> Model a
+init : a -> List a -> Bool -> Selection a -> Model a
 init head tail showQuickSelect initialSelection =
     let
         ( lower, upper ) =
-            range initialSelection (List.length tail + 1)
+            rangeIndices initialSelection (Cons.cons head tail)
     in
     Model
         { options = Cons.cons head tail
@@ -74,18 +74,28 @@ init head tail showQuickSelect initialSelection =
         }
 
 
-update : Selection -> Model a -> Model a
+update : Selection a -> Model a -> Model a
 update msg (Model m) =
     let
         ( lower, upper ) =
-            range msg (Cons.length m.options)
+            rangeIndices msg m.options
     in
     Model { m | min = lower, max = upper }
 
 
-range : Selection -> Int -> ( Int, Int )
-range selection n =
-    case selection of
+rangeIndices : Selection a -> Cons a -> ( Int, Int )
+rangeIndices msg options =
+    let
+        n =
+            Cons.length options
+
+        indexOfMin =
+            find options >> Maybe.withDefault 0
+
+        indexOfMax =
+            find options >> Maybe.withDefault (n - 1)
+    in
+    case msg of
         All ->
             ( 0, n - 1 )
 
@@ -93,7 +103,20 @@ range selection n =
             ( Basics.max 0 (n - count), n - 1 )
 
         Range l u ->
-            ( l, u )
+            ( indexOfMin l, indexOfMax u )
+
+
+range : Cons a -> Int -> Int -> Selection a
+range options i j =
+    Range (get options i) (get options j)
+
+
+find : Cons a -> a -> Maybe Int
+find options a =
+    Cons.indexedMap Tuple.pair options
+        |> Cons.filter (\( _, b ) -> b == a)
+        |> List.map Tuple.first
+        |> List.head
 
 
 get : Cons a -> Int -> a
@@ -101,7 +124,7 @@ get options i =
     options |> Cons.drop i |> List.head |> Maybe.withDefault (Cons.head options)
 
 
-view : String -> (a -> String) -> Model a -> Element Selection
+view : String -> (a -> String) -> Model a -> Element (Selection a)
 view label format model =
     case model of
         Model m ->
@@ -136,13 +159,13 @@ view label format model =
                             ( m.min + 1 - pad, m.min )
 
                 sliderMin =
-                    slider Min lSize 0 lMax m.min (round >> (\i -> Range i m.max))
+                    slider Min lSize 0 lMax m.min (round >> (\i -> range m.options i m.max))
 
                 sliderMax =
-                    slider Max rSize rMin (n - 1) m.max (round >> (\i -> Range m.min i))
+                    slider Max rSize rMin (n - 1) m.max (round >> (\i -> range m.options m.min i))
 
                 btn msg s =
-                    if ( m.min, m.max ) == range msg (Cons.length m.options) then
+                    if ( m.min, m.max ) == rangeIndices msg m.options then
                         disabledButton s
 
                     else
@@ -192,7 +215,7 @@ thumbSize =
     size.m
 
 
-slider : Side -> Int -> Int -> Int -> Int -> (Float -> Selection) -> Element Selection
+slider : Side -> Int -> Int -> Int -> Int -> (Float -> Selection a) -> Element (Selection a)
 slider side n minIdx maxIdx valIdx onChangeMsg =
     let
         ( label, handle ) =

--- a/src/Effect.elm
+++ b/src/Effect.elm
@@ -15,6 +15,7 @@ port module Effect exposing
     , saveToLocalStorage
     , sendCmd
     , sendMsg
+    , setDateRange
     , store
     , toCmd
     , truncateDatabase
@@ -29,6 +30,7 @@ import Route.Path
 import Shared.Model
 import Shared.Msg exposing (Msg(..))
 import Task
+import Time.Date exposing (Date)
 import Url exposing (Url)
 
 
@@ -179,6 +181,15 @@ store data =
 saveToLocalStorage : Data -> Effect msg
 saveToLocalStorage data =
     SaveToLocalStorage data
+
+
+
+-- GLOBAL APP STATE
+
+
+setDateRange : Maybe Date -> Maybe Date -> Effect msg
+setDateRange min max =
+    SendSharedMsg <| SetDateRange min max
 
 
 

--- a/src/Pages/AddData.elm
+++ b/src/Pages/AddData.elm
@@ -39,7 +39,7 @@ import Util.Layout exposing (dataInit, dataUpdate, dataView)
 page : Shared.Model -> Route () -> Page Model Msg
 page shared _ =
     Page.new
-        { init = \_ -> dataInit shared initialModel (\_ -> initialModel)
+        { init = \_ -> dataInit shared initialModel (\_ _ -> initialModel)
         , update = dataUpdate shared update
         , subscriptions = \_ -> Sub.none
         , view = dataView shared "Import Data" view
@@ -172,12 +172,19 @@ updateLoaded data loaded msg =
 
                 newData =
                     data |> Storage.addEntries newEntries
+
+                min =
+                    newEntries |> List.map .date |> List.Extra.minimumWith Date.compare
+
+                max =
+                    newEntries |> List.map .date |> List.Extra.maximumWith Date.compare
             in
             -- TODO add a (global) notification about the entries added
             -- model | notification = storeConfirmation (List.length newEntries)
             ( initialModel
             , Effect.batch
                 [ Effect.store newData
+                , Effect.setDateRange min max
                 , Process.sleep 10
                     |> Task.perform (\_ -> Forward)
                     |> Effect.sendCmd

--- a/src/Pages/AddData.elm
+++ b/src/Pages/AddData.elm
@@ -89,7 +89,7 @@ type Msg
     | StoreNewProfile ImportProfile
     | ProfileBuilderMsg ProfileBuilder.Msg
     | ChooseAccount Account
-    | FilterMsg RangeSlider.Selection
+    | FilterMsg (RangeSlider.Selection Date)
     | AbortImport
     | Store (List ParsedRow) (List String) Account ImportProfile
     | Forward

--- a/src/Pages/Aggregation.elm
+++ b/src/Pages/Aggregation.elm
@@ -60,7 +60,7 @@ type Tab
 
 
 type alias Model =
-    { filters : Filter.Model Msg
+    { filters : Filter.Model
     , ordering : Ordering MonthAggregate
     , tab : Tab
     , edit : Maybe ( YearMonth, String )
@@ -123,7 +123,7 @@ initFromData data =
 
 init : List Account -> List AggregationGroup -> List RawEntry -> Model
 init accounts groups entries =
-    { filters = Filter.init accounts [] (List.map .date entries) Filter
+    { filters = Filter.init accounts [] (List.map .date entries)
     , ordering = desc aggregateMonth
     , tab = Overview
     , edit = Nothing
@@ -159,7 +159,7 @@ update data msg model =
                 ( filters, effect ) =
                     Filter.update filterMsg model.filters
             in
-            ( { model | filters = filters }, effect )
+            ( { model | filters = filters }, effect |> Effect.map Filter )
 
         ( OrderBy ordering, _ ) ->
             ( { model | ordering = ordering }, Effect.none )
@@ -446,6 +446,7 @@ viewFilters model accounts =
         [ Filter.accountFilter accounts model.filters
         , Filter.dateRangeFilter model.filters
         ]
+        |> Element.map Filter
 
 
 showAggResults : Audits -> Maybe ( YearMonth, String ) -> List MonthAggregate -> List (IndexedColumn MonthAggregate Msg) -> Element Msg

--- a/src/Pages/Aggregation.elm
+++ b/src/Pages/Aggregation.elm
@@ -33,6 +33,8 @@ import Processing.Model exposing (getEntries)
 import Processing.Ordering exposing (Ordering, aggregateMonth, asc, bookEntryDate, desc)
 import Route exposing (Route)
 import Shared exposing (dataSummary)
+import Shared.Model exposing (AppState)
+import Time.Date exposing (Date)
 import Util.Formats exposing (formatEuro, formatYearMonth)
 import Util.Layout exposing (dataInit, dataUpdate, dataView)
 import Util.YearMonth exposing (YearMonth)
@@ -41,7 +43,7 @@ import Util.YearMonth exposing (YearMonth)
 page : Shared.Model -> Route () -> Page Model Msg
 page shared _ =
     Page.new
-        { init = \_ -> dataInit shared (init [] [] []) initFromData
+        { init = \_ -> dataInit shared (init [] [] [] Nothing) initFromData
         , update = dataUpdate shared update
         , view = dataView shared "Monthly" view
         , subscriptions = \_ -> Sub.none
@@ -116,14 +118,18 @@ prompt items =
             ]
 
 
-initFromData : Data -> Model
-initFromData data =
-    init (Dict.values data.accounts) [] (Dict.values data.rawEntries.entries)
+initFromData : Data -> AppState -> Model
+initFromData data state =
+    let
+        currentDateRange =
+            Maybe.map2 Tuple.pair state.min state.max
+    in
+    init (Dict.values data.accounts) [] (Dict.values data.rawEntries.entries) currentDateRange
 
 
-init : List Account -> List AggregationGroup -> List RawEntry -> Model
-init accounts groups entries =
-    { filters = Filter.init accounts [] (List.map .date entries)
+init : List Account -> List AggregationGroup -> List RawEntry -> Maybe ( Date, Date ) -> Model
+init accounts groups entries currentDateRange =
+    { filters = Filter.init accounts [] (List.map .date entries) currentDateRange
     , ordering = desc aggregateMonth
     , tab = Overview
     , edit = Nothing
@@ -158,8 +164,11 @@ update data msg model =
             let
                 ( filters, effect ) =
                     Filter.update filterMsg model.filters
+
+                ( minDate, maxDate ) =
+                    Filter.getDateRange filters
             in
-            ( { model | filters = filters }, effect |> Effect.map Filter )
+            ( { model | filters = filters }, Effect.batch [ effect |> Effect.map Filter, Effect.setDateRange (Just minDate) (Just maxDate) ] )
 
         ( OrderBy ordering, _ ) ->
             ( { model | ordering = ordering }, Effect.none )

--- a/src/Pages/Home_.elm
+++ b/src/Pages/Home_.elm
@@ -36,7 +36,7 @@ type alias Model =
 init : Shared.Model -> ( Model, Effect Msg )
 init shared =
     case shared of
-        Loaded _ ->
+        Loaded _ _ ->
             ( {}, Effect.pushRoutePath Path.Book )
 
         _ ->
@@ -53,7 +53,7 @@ type Msg
 update : Shared.Model -> Msg -> Model -> ( Model, Effect Msg )
 update shared msg model =
     case shared of
-        Loaded _ ->
+        Loaded _ _ ->
             ( {}, Effect.pushRoutePath Path.Book )
 
         _ ->
@@ -91,7 +91,7 @@ view sharedModel model =
 
 actionsFor sharedModel =
     case sharedModel of
-        Loaded _ ->
+        Loaded _ _ ->
             [ Element.none ]
 
         None ->

--- a/src/Pages/Settings.elm
+++ b/src/Pages/Settings.elm
@@ -18,7 +18,7 @@ import Util.Layout exposing (dataInit, dataUpdate, dataView)
 page : Shared.Model -> Route () -> Page Model Msg
 page shared route =
     Page.new
-        { init = \_ -> dataInit shared init (\_ -> init)
+        { init = \_ -> dataInit shared init (\_ _ -> init)
         , update = dataUpdate shared update
         , subscriptions = \_ -> Sub.none
         , view = dataView shared "Settings" view

--- a/src/Shared/Model.elm
+++ b/src/Shared/Model.elm
@@ -1,4 +1,4 @@
-module Shared.Model exposing (Model(..))
+module Shared.Model exposing (AppState, Model(..))
 
 {-| Normally, this value would live in "Shared.elm"
 but that would lead to a circular dependency import cycle.
@@ -10,9 +10,16 @@ own file, so they can be imported by `Effect.elm`
 
 import Json.Decode exposing (Error)
 import Persistence.Data exposing (Data)
+import Time.Date exposing (Date)
 
 
 type Model
     = None
-    | Loaded Data
+    | Loaded Data AppState
     | Problem Error
+
+
+type alias AppState =
+    { min : Maybe Date
+    , max : Maybe Date
+    }

--- a/src/Shared/Msg.elm
+++ b/src/Shared/Msg.elm
@@ -1,6 +1,7 @@
 module Shared.Msg exposing (Msg(..))
 
 import Persistence.Data exposing (Data)
+import Time.Date exposing (Date)
 
 
 {-| Normally, this value would live in "Shared.elm"
@@ -15,3 +16,4 @@ type Msg
     | LoadDatabase String
     | Update Data
     | CloseDB
+    | SetDateRange (Maybe Date) (Maybe Date)

--- a/src/Util/Layout.elm
+++ b/src/Util/Layout.elm
@@ -9,7 +9,7 @@ import Element exposing (..)
 import Persistence.Data exposing (Data)
 import Route.Path
 import Shared exposing (Model)
-import Shared.Model exposing (Model(..))
+import Shared.Model exposing (AppState, Model(..))
 import View exposing (View)
 
 
@@ -24,7 +24,7 @@ dataView shared pageTitle content model =
             Problem _ ->
                 Element.text "Error"
 
-            Loaded data ->
+            Loaded data _ ->
                 content data model
     }
 
@@ -36,18 +36,18 @@ type alias UpdateFn msg model =
 dataUpdate : Shared.Model -> (Data -> UpdateFn msg model) -> UpdateFn msg model
 dataUpdate shared update =
     case shared of
-        Loaded data ->
+        Loaded data _ ->
             update data
 
         _ ->
             \_ model -> ( model, Effect.pushRoutePath Route.Path.Home_ )
 
 
-dataInit : Shared.Model -> model -> (Data -> model) -> ( model, Effect msg )
+dataInit : Shared.Model -> model -> (Data -> AppState -> model) -> ( model, Effect msg )
 dataInit shared dummy init =
     case shared of
-        Loaded data ->
-            ( init data, Effect.none )
+        Loaded data query ->
+            ( init data query, Effect.none )
 
         _ ->
             ( dummy, Effect.pushRoutePath Route.Path.Home_ )

--- a/tests/FlagsDecoder.elm
+++ b/tests/FlagsDecoder.elm
@@ -1,0 +1,21 @@
+module FlagsDecoder exposing (..)
+
+import Expect
+import Json.Decode
+import Persistence.Data as Data
+import Shared
+import Test exposing (Test, describe, test)
+
+
+emptyDBString =
+    "\"[1,[4,[[1,[0,[]]],[],[],[],[0,[]],[0,[0,0,[]]],0]]]\""
+
+
+format_euro_str : Test
+format_euro_str =
+    describe "Format Cent values to euros"
+        [ test "handles the empty string" <|
+            \_ -> Json.Decode.decodeString Shared.decoder "\"\"" |> Expect.equal (Ok Nothing)
+        , test "imports data" <|
+            \_ -> Json.Decode.decodeString Shared.decoder emptyDBString |> Expect.equal (Ok <| Just Data.empty)
+        ]


### PR DESCRIPTION
After importing data, forward to the Book view while maintaining the window of imported dates as the selected time range, allowing for quick review after import.

In order to achieve this, add global date range state, finally allowing to switch between Aggregated and Book view without losing temporal focus.